### PR TITLE
fix: correct duration handling to match API signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ From there, it's as simple as creating a new `bubbleup.AlertModel` by calling `b
 **Basic Example**:
 ```go
 // Create alert model: max width=50, use NerdFont, 10 second duration
-alertModel := bubbleup.NewAlertModel(50, true, 10)
+alertModel := bubbleup.NewAlertModel(50, true, 10*time.Second)
 
 m := myModel{
     alert: alertModel,
@@ -62,7 +62,7 @@ See the **Configuration Options** section below for advanced features like posit
 BubbleUp supports method chaining for configuration. All `With*()` methods return the modified `AlertModel`, allowing you to chain multiple configurations:
 
 ```go
-m.alert = bubbleup.NewAlertModel(50, false, 10).
+m.alert = bubbleup.NewAlertModel(50, false, 10*time.Second).
     WithMinWidth(15).                              // Enable dynamic width (15-50 chars)
     WithPosition(bubbleup.TopRightPosition).       // Position at top-right
     WithUnicodePrefix().                           // Use Unicode symbols
@@ -112,7 +112,7 @@ By default, alerts have a fixed width set by the `width` parameter passed to `Ne
 **Example**:
 ```go
 // Create with max width 50, enable dynamic sizing with min 15
-m.alert = bubbleup.NewAlertModel(50, true, 10).WithMinWidth(15)
+m.alert = bubbleup.NewAlertModel(50, true, 10*time.Second).WithMinWidth(15)
 
 // Short message: alert will be ~15-20 chars wide
 alertCmd = m.alert.NewAlertCmd(bubbleup.InfoKey, "Done")
@@ -158,13 +158,13 @@ BubbleUp supports three font/symbol options for alert prefixes:
 **Example**:
 ```go
 // Unicode fonts (recommended for portability)
-m.alert = bubbleup.NewAlertModel(50, false, 10).WithUnicodePrefix()
+m.alert = bubbleup.NewAlertModel(50, false, 10*time.Second).WithUnicodePrefix()
 
 // NerdFont (requires NerdFont installation on user's system)
-m.alert = bubbleup.NewAlertModel(50, true, 10)
+m.alert = bubbleup.NewAlertModel(50, true, 10*time.Second)
 
 // ASCII (maximum compatibility)
-m.alert = bubbleup.NewAlertModel(50, false, 10)
+m.alert = bubbleup.NewAlertModel(50, false, 10*time.Second)
 ```
 
 ### Keyboard Interaction
@@ -172,7 +172,7 @@ m.alert = bubbleup.NewAlertModel(50, false, 10)
 Enable `Esc` key to dismiss alerts before their timeout:
 
 ```go
-m.alert = bubbleup.NewAlertModel(50, true, 10).WithAllowEscToClose()
+m.alert = bubbleup.NewAlertModel(50, true, 10*time.Second).WithAllowEscToClose()
 ```
 
 **Handling `Esc` key in Your `Update()` Method**:

--- a/alert.go
+++ b/alert.go
@@ -216,7 +216,7 @@ type AlertDefinition struct {
 // returned tea.Cmd should be batched into your return.
 func (m AlertModel) NewAlertCmd(alertType, message string) tea.Cmd {
 	return func() tea.Msg {
-		return alertMsg{alertKey: alertType, msg: message, dur: time.Second * m.duration}
+		return alertMsg{alertKey: alertType, msg: message, dur: m.duration}
 	}
 }
 

--- a/examples/example_main.go
+++ b/examples/example_main.go
@@ -53,9 +53,9 @@ func main() {
 		// BEGIN here to understand how to create and use Bubble Up
 
 		// Create a new alert model and embed it within your program's model
-		//  width = 50 (max), minWidth = 10, duration = 10
+		//  width = 50 (max), minWidth = 10, duration = 10 seconds
 		// useNerdFont = default is false, but example app user can change.
-		m.alert = bubbleup.NewAlertModel(50, useNerdFont, 10).
+		m.alert = bubbleup.NewAlertModel(50, useNerdFont, 10*time.Second).
 			WithMinWidth(15).     // Dynamic width: alerts will size 15-50 chars
 			WithAllowEscToClose() // Allow <esc> to close an alert before timeout
 		// based on message length

--- a/model.go
+++ b/model.go
@@ -126,6 +126,11 @@ func (m AlertModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.activeAlert = nil
 
+	default:
+		// For any other message type, keep ticking if alert is active
+		if m.activeAlert != nil {
+			return m, tickCmd()
+		}
 	}
 
 	return m, nil


### PR DESCRIPTION
The `NewAlertModel()` signature expects `time.Duration`, but `NewAlertCmd` was [incorrectly multiplying `m.duration` by `time.Second`](https://github.com/DaltonSW/BubbleUp/pull/4/changes/32eb771a910ed4399741cff2360de5702c5bcf78#diff-0ac0ad254c0aec99dc10fb85024c37e97ada12832a9c2b9256bdbe3573f946e8R154), causing timeouts passed as a `time.Duration` vs. as an `int` to be wrong

Changes:
- `alert.go`: Removed `time.Second` multiplication from `NewAlertCmd()` 
- `model.go`: Added default case to continue ticking on non-alert messages
- `README.md`: Updated all examples to use `N*time.Second` syntax
- `examples/example_main.go`: Updated to use `10*time.Second`

**BREAKING CHANGE** _(since PR #4):_ Code passing raw integers (e.g., `10`) will now correctly receive `10 nanoseconds` instead of incorrectly receiving `10 seconds`. Update code to use proper `time.Duration` values e.g., `10*time.Second`.

This change views the parameter type of `time.Duration` as authoritative and makes its use reflect the intent of the data type rather than treat it as if it were an int.